### PR TITLE
Update .gitmodules for https url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "external/XMem"]
 	path = external/XMem
-	url = git@github.com:hkchengrex/XMem.git
+	url = https://github.com/hkchengrex/XMem.git


### PR DESCRIPTION
This pull request includes a small change to the `.gitmodules` file. The change updates the URL of the `XMem` submodule to use HTTPS instead of SSH.

* [`.gitmodules`](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584L3-R3): Changed the URL of the `XMem` submodule from `git@github.com:hkchengrex/XMem.git` to `https://github.com/hkchengrex/XMem.git`.